### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/101/797/973/101797973.geojson
+++ b/data/101/797/973/101797973.geojson
@@ -186,6 +186,9 @@
         "qs_pg:id":483028
     },
     "wof:country":"SM",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f4c0076ba49105c6e60daaa97fcadfba",
     "wof:hierarchy":[
         {
@@ -196,7 +199,7 @@
         }
     ],
     "wof:id":101797973,
-    "wof:lastmodified":1566647916,
+    "wof:lastmodified":1582314024,
     "wof:name":"Fiorentino",
     "wof:parent_id":85677205,
     "wof:placetype":"locality",

--- a/data/101/837/377/101837377.geojson
+++ b/data/101/837/377/101837377.geojson
@@ -243,6 +243,9 @@
         "wk:page":"Domagnano"
     },
     "wof:country":"SM",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ae496f89b3bd30ed94c3069d79d89d58",
     "wof:hierarchy":[
         {
@@ -253,7 +256,7 @@
         }
     ],
     "wof:id":101837377,
-    "wof:lastmodified":1566647916,
+    "wof:lastmodified":1582314024,
     "wof:name":"Domagnano",
     "wof:parent_id":85677199,
     "wof:placetype":"locality",

--- a/data/101/837/379/101837379.geojson
+++ b/data/101/837/379/101837379.geojson
@@ -256,6 +256,9 @@
         "wk:page":"Serravalle (San Marino)"
     },
     "wof:country":"SM",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bb1775928af4340f66e78f5e9809a6a4",
     "wof:hierarchy":[
         {
@@ -266,7 +269,7 @@
         }
     ],
     "wof:id":101837379,
-    "wof:lastmodified":1566647916,
+    "wof:lastmodified":1582314024,
     "wof:name":"Serravalle",
     "wof:parent_id":85677211,
     "wof:placetype":"locality",

--- a/data/101/852/291/101852291.geojson
+++ b/data/101/852/291/101852291.geojson
@@ -124,6 +124,9 @@
         "qs_pg:id":489944
     },
     "wof:country":"SM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"aeb70ce4c6512e0717f04ca3c527321f",
     "wof:hierarchy":[
         {
@@ -134,7 +137,7 @@
         }
     ],
     "wof:id":101852291,
-    "wof:lastmodified":1566647917,
+    "wof:lastmodified":1582314024,
     "wof:name":"Acquaviva",
     "wof:parent_id":85677209,
     "wof:placetype":"locality",

--- a/data/421/202/109/421202109.geojson
+++ b/data/421/202/109/421202109.geojson
@@ -56,6 +56,9 @@
     },
     "wof:country":"SM",
     "wof:created":1459010105,
+    "wof:geom_alt":[
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"fe9d219080c30270cb0acc75d2c5033e",
     "wof:hierarchy":[
         {
@@ -64,7 +67,7 @@
         }
     ],
     "wof:id":421202109,
-    "wof:lastmodified":1527716209,
+    "wof:lastmodified":1582314024,
     "wof:name":"San Marino",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/856/771/99/85677199.geojson
+++ b/data/856/771/99/85677199.geojson
@@ -329,6 +329,9 @@
         "wk:page":"Borgo Maggiore"
     },
     "wof:country":"SM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e2e36130e5e911ffcc3429144d2b7b5f",
     "wof:hierarchy":[
         {
@@ -344,7 +347,7 @@
     "wof:lang_x_spoken":[
         "ita"
     ],
-    "wof:lastmodified":1566647914,
+    "wof:lastmodified":1582314024,
     "wof:name":"Borgo Maggiore",
     "wof:parent_id":85633763,
     "wof:placetype":"region",

--- a/data/856/772/05/85677205.geojson
+++ b/data/856/772/05/85677205.geojson
@@ -510,6 +510,9 @@
         "wd:id":"Q1848"
     },
     "wof:country":"SM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"96f3f0f9086f7f13dd3f49b56d7eb7d7",
     "wof:hierarchy":[
         {
@@ -525,7 +528,7 @@
     "wof:lang_x_spoken":[
         "ita"
     ],
-    "wof:lastmodified":1566647914,
+    "wof:lastmodified":1582314024,
     "wof:name":"San Marino",
     "wof:parent_id":85633763,
     "wof:placetype":"region",

--- a/data/856/772/09/85677209.geojson
+++ b/data/856/772/09/85677209.geojson
@@ -322,6 +322,9 @@
         "wk:page":"Acquaviva (San Marino)"
     },
     "wof:country":"SM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d66b658d9eea6ab8933167dfbf5ba384",
     "wof:hierarchy":[
         {
@@ -337,7 +340,7 @@
     "wof:lang_x_spoken":[
         "ita"
     ],
-    "wof:lastmodified":1566647915,
+    "wof:lastmodified":1582314024,
     "wof:name":"Acquaviva",
     "wof:parent_id":85633763,
     "wof:placetype":"region",

--- a/data/856/772/11/85677211.geojson
+++ b/data/856/772/11/85677211.geojson
@@ -345,6 +345,9 @@
         "wd:id":"Q185412"
     },
     "wof:country":"SM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6d89feae1bf9676d30bb3a498235296c",
     "wof:hierarchy":[
         {
@@ -360,7 +363,7 @@
     "wof:lang_x_spoken":[
         "ita"
     ],
-    "wof:lastmodified":1566647914,
+    "wof:lastmodified":1582314024,
     "wof:name":"Serravalle",
     "wof:parent_id":85633763,
     "wof:placetype":"region",

--- a/data/856/772/15/85677215.geojson
+++ b/data/856/772/15/85677215.geojson
@@ -312,6 +312,9 @@
         "wd:id":"Q202202"
     },
     "wof:country":"SM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e7b055a25ee02a450611ebfbd44b6a72",
     "wof:hierarchy":[
         {
@@ -327,7 +330,7 @@
     "wof:lang_x_spoken":[
         "ita"
     ],
-    "wof:lastmodified":1566647915,
+    "wof:lastmodified":1582314024,
     "wof:name":"Domagnano",
     "wof:parent_id":85633763,
     "wof:placetype":"region",

--- a/data/856/772/21/85677221.geojson
+++ b/data/856/772/21/85677221.geojson
@@ -332,6 +332,9 @@
         "wk:page":"Faetano"
     },
     "wof:country":"SM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e2510d46463212c508731350e10b2dbe",
     "wof:hierarchy":[
         {
@@ -347,7 +350,7 @@
     "wof:lang_x_spoken":[
         "ita"
     ],
-    "wof:lastmodified":1566647915,
+    "wof:lastmodified":1582314024,
     "wof:name":"Faetano",
     "wof:parent_id":85633763,
     "wof:placetype":"region",

--- a/data/856/772/25/85677225.geojson
+++ b/data/856/772/25/85677225.geojson
@@ -322,6 +322,9 @@
         "wk:page":"Montegiardino"
     },
     "wof:country":"SM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fbd1c9cc35e48878e3760eb8811e1076",
     "wof:hierarchy":[
         {
@@ -337,7 +340,7 @@
     "wof:lang_x_spoken":[
         "ita"
     ],
-    "wof:lastmodified":1566647915,
+    "wof:lastmodified":1582314024,
     "wof:name":"Montegiardino",
     "wof:parent_id":85633763,
     "wof:placetype":"region",

--- a/data/856/772/27/85677227.geojson
+++ b/data/856/772/27/85677227.geojson
@@ -316,6 +316,9 @@
         "wk:page":"Fiorentino"
     },
     "wof:country":"SM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5e3f0c71205754055a0ea29733ae9e55",
     "wof:hierarchy":[
         {
@@ -331,7 +334,7 @@
     "wof:lang_x_spoken":[
         "ita"
     ],
-    "wof:lastmodified":1566647914,
+    "wof:lastmodified":1582314024,
     "wof:name":"Fiorentino",
     "wof:parent_id":85633763,
     "wof:placetype":"region",

--- a/data/856/772/31/85677231.geojson
+++ b/data/856/772/31/85677231.geojson
@@ -333,6 +333,9 @@
         "wk:page":"Chiesanuova"
     },
     "wof:country":"SM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b1f292b75ea6c4635a0089798bf9f588",
     "wof:hierarchy":[
         {
@@ -348,7 +351,7 @@
     "wof:lang_x_spoken":[
         "ita"
     ],
-    "wof:lastmodified":1566647915,
+    "wof:lastmodified":1582314024,
     "wof:name":"Chiesanuova",
     "wof:parent_id":85633763,
     "wof:placetype":"region",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.