### PR TITLE
sm concordances, placetype local, and more

### DIFF
--- a/data/856/337/63/85633763.geojson
+++ b/data/856/337/63/85633763.geojson
@@ -1208,6 +1208,7 @@
         "hasc:id":"SM",
         "icao:code":"T7",
         "ioc:id":"SMR",
+        "iso:code":"SM",
         "itu:id":"SMR",
         "loc:id":"n81117285",
         "m49:code":"674",
@@ -1219,6 +1220,7 @@
         "wd:id":"Q238",
         "wk:page":"San Marino"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SM",
     "wof:country_alpha3":"SMR",
     "wof:geomhash":"5353beb7dc3b738bea818713e5b22955",
@@ -1235,7 +1237,7 @@
     "wof:lang_x_spoken":[
         "ita"
     ],
-    "wof:lastmodified":1694639499,
+    "wof:lastmodified":1695881153,
     "wof:name":"San Marino",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/856/771/99/85677199.geojson
+++ b/data/856/771/99/85677199.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001249,
-    "geom:area_square_m":11123778.723462,
+    "geom:area_square_m":11123649.575687,
     "geom:bbox":"12.43913,43.914485,12.487677,43.968966",
     "geom:latitude":43.940985,
     "geom:longitude":12.460994,
@@ -339,6 +339,7 @@
         "gn:id":3345304,
         "gp:id":20070544,
         "hasc:id":"SM.BM",
+        "iso:code":"SM-06",
         "iso:id":"SM-06",
         "loc:id":"nb2009017380",
         "qs_pg:id":1102989,
@@ -346,11 +347,12 @@
         "wd:id":"Q201368",
         "wk:page":"Borgo Maggiore"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"365634ec8a9ca27bc37d854f588f49ea",
+    "wof:geomhash":"3b5530b1fa156a53a6e9f6b83a11a0db",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -365,7 +367,7 @@
     "wof:lang_x_spoken":[
         "ita"
     ],
-    "wof:lastmodified":1690865843,
+    "wof:lastmodified":1695884331,
     "wof:name":"Borgo Maggiore",
     "wof:parent_id":85633763,
     "wof:placetype":"region",

--- a/data/856/772/05/85677205.geojson
+++ b/data/856/772/05/85677205.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000916,
-    "geom:area_square_m":8156167.369857,
+    "geom:area_square_m":8156137.837185,
     "geom:bbox":"12.408032,43.903966,12.462055,43.940646",
     "geom:latitude":43.920963,
     "geom:longitude":12.441519,
@@ -556,15 +556,17 @@
         "gn:id":3345302,
         "gp:id":20070545,
         "hasc:id":"SM.SM",
+        "iso:code":"SM-07",
         "iso:id":"SM-07",
         "qs_pg:id":466351,
         "wd:id":"Q1848"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"114b20b478ed84bcb3e0b77f2674f6ff",
+    "wof:geomhash":"7078be1e969a1a5c934affd7d5e9d1f6",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -579,7 +581,7 @@
     "wof:lang_x_spoken":[
         "ita"
     ],
-    "wof:lastmodified":1690865844,
+    "wof:lastmodified":1695884331,
     "wof:name":"San Marino",
     "wof:parent_id":85633763,
     "wof:placetype":"region",

--- a/data/856/772/09/85677209.geojson
+++ b/data/856/772/09/85677209.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00097,
-    "geom:area_square_m":8640247.455875,
+    "geom:area_square_m":8640243.835163,
     "geom:bbox":"12.403652,43.925007,12.447491,43.961379",
     "geom:latitude":43.944077,
     "geom:longitude":12.424806,
@@ -330,17 +330,19 @@
         "gn:id":3345303,
         "gp:id":20070543,
         "hasc:id":"SM.AC",
+        "iso:code":"SM-01",
         "iso:id":"SM-01",
         "qs_pg:id":1102988,
         "unlc:id":"SM-01",
         "wd:id":"Q206363",
         "wk:page":"Acquaviva (San Marino)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"34aa1ca2b069cd5f753a255c1b1467ac",
+    "wof:geomhash":"252867b788eb8dd72ee5e3aa86eb0ae6",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -355,7 +357,7 @@
     "wof:lang_x_spoken":[
         "ita"
     ],
-    "wof:lastmodified":1690865845,
+    "wof:lastmodified":1695884331,
     "wof:name":"Acquaviva",
     "wof:parent_id":85633763,
     "wof:placetype":"region",

--- a/data/856/772/11/85677211.geojson
+++ b/data/856/772/11/85677211.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001174,
-    "geom:area_square_m":10450245.790268,
+    "geom:area_square_m":10450056.481929,
     "geom:bbox":"12.451903,43.951974,12.515894,43.991993",
     "geom:latitude":43.97167,
     "geom:longitude":12.488534,
@@ -360,16 +360,18 @@
         "gn:id":3166650,
         "gp:id":20070551,
         "hasc:id":"SM.SE",
+        "iso:code":"SM-09",
         "iso:id":"SM-09",
         "qs_pg:id":1094510,
         "unlc:id":"SM-09",
         "wd:id":"Q185412"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d0e543ca1e17088ea59f277d7463bf8d",
+    "wof:geomhash":"6c5e7b65479855fee67d852d5442574c",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -384,7 +386,7 @@
     "wof:lang_x_spoken":[
         "ita"
     ],
-    "wof:lastmodified":1690865844,
+    "wof:lastmodified":1695884331,
     "wof:name":"Serravalle",
     "wof:parent_id":85633763,
     "wof:placetype":"region",

--- a/data/856/772/15/85677215.geojson
+++ b/data/856/772/15/85677215.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000825,
-    "geom:area_square_m":7342913.870442,
+    "geom:area_square_m":7342870.312602,
     "geom:bbox":"12.465831,43.933364,12.513034,43.963676",
     "geom:latitude":43.94845,
     "geom:longitude":12.487808,
@@ -324,16 +324,18 @@
         "gn:id":3345305,
         "gp:id":20070547,
         "hasc:id":"SM.DO",
+        "iso:code":"SM-03",
         "iso:id":"SM-03",
         "qs_pg:id":1102990,
         "unlc:id":"SM-03",
         "wd:id":"Q202202"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"982b116fdb6daa7d0bdc429c524c5bbb",
+    "wof:geomhash":"f670100cb6cdd461a178f64f0af5857a",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -348,7 +350,7 @@
     "wof:lang_x_spoken":[
         "ita"
     ],
-    "wof:lastmodified":1690865845,
+    "wof:lastmodified":1695884331,
     "wof:name":"Domagnano",
     "wof:parent_id":85633763,
     "wof:placetype":"region",

--- a/data/856/772/21/85677221.geojson
+++ b/data/856/772/21/85677221.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000515,
-    "geom:area_square_m":4585039.319941,
+    "geom:area_square_m":4585025.725919,
     "geom:bbox":"12.478238,43.921713,12.515936,43.949473",
     "geom:latitude":43.934176,
     "geom:longitude":12.499255,
@@ -342,6 +342,7 @@
         "gn:id":3345306,
         "gp:id":20070548,
         "hasc:id":"SM.FA",
+        "iso:code":"SM-04",
         "iso:id":"SM-04",
         "loc:id":"no2013074704",
         "qs_pg:id":1294213,
@@ -349,11 +350,12 @@
         "wd:id":"Q206356",
         "wk:page":"Faetano"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b7a454dbcd3ddd5ee50418e11f34b7d6",
+    "wof:geomhash":"a7625543c268afa897016f9fe5435390",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -368,7 +370,7 @@
     "wof:lang_x_spoken":[
         "ita"
     ],
-    "wof:lastmodified":1690865845,
+    "wof:lastmodified":1695884331,
     "wof:name":"Faetano",
     "wof:parent_id":85633763,
     "wof:placetype":"region",

--- a/data/856/772/25/85677225.geojson
+++ b/data/856/772/25/85677225.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000175,
-    "geom:area_square_m":1562275.51302,
+    "geom:area_square_m":1562274.988416,
     "geom:bbox":"12.484171,43.89711,12.497906,43.923655",
     "geom:latitude":43.911313,
     "geom:longitude":12.48941,
@@ -329,6 +329,7 @@
         "gn:id":3345308,
         "gp:id":20070550,
         "hasc:id":"SM.MG",
+        "iso:code":"SM-08",
         "iso:id":"SM-08",
         "loc:id":"n83232696",
         "qs_pg:id":582889,
@@ -336,11 +337,12 @@
         "wd:id":"Q206962",
         "wk:page":"Montegiardino"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"22bb20e79a3ecfe1b3904ac763bc27b2",
+    "wof:geomhash":"2938e8b8485704d7ccba4bad2f46b6b0",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -355,7 +357,7 @@
     "wof:lang_x_spoken":[
         "ita"
     ],
-    "wof:lastmodified":1690865846,
+    "wof:lastmodified":1695884331,
     "wof:name":"Montegiardino",
     "wof:parent_id":85633763,
     "wof:placetype":"region",

--- a/data/856/772/27/85677227.geojson
+++ b/data/856/772/27/85677227.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000526,
-    "geom:area_square_m":4689104.136804,
+    "geom:area_square_m":4689180.597128,
     "geom:bbox":"12.456121,43.894634,12.489026,43.924464",
     "geom:latitude":43.90712,
     "geom:longitude":12.473569,
@@ -321,17 +321,19 @@
         "gn:id":3345307,
         "gp:id":20070549,
         "hasc:id":"SM.FI",
+        "iso:code":"SM-05",
         "iso:id":"SM-05",
         "qs_pg:id":1094524,
         "unlc:id":"SM-05",
         "wd:id":"Q206968",
         "wk:page":"Fiorentino"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"48e455e920fcefabb8f135ca64a2282b",
+    "wof:geomhash":"d388ab785138b7ce1cdaa994be6ee54b",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -346,7 +348,7 @@
     "wof:lang_x_spoken":[
         "ita"
     ],
-    "wof:lastmodified":1690865844,
+    "wof:lastmodified":1695884331,
     "wof:name":"Fiorentino",
     "wof:parent_id":85633763,
     "wof:placetype":"region",

--- a/data/856/772/31/85677231.geojson
+++ b/data/856/772/31/85677231.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000567,
-    "geom:area_square_m":5050396.652453,
+    "geom:area_square_m":5050619.760388,
     "geom:bbox":"12.408231,43.894294,12.461042,43.918261",
     "geom:latitude":43.907859,
     "geom:longitude":12.430138,
@@ -341,17 +341,19 @@
         "gn:id":3178807,
         "gp:id":20070546,
         "hasc:id":"SM.CH",
+        "iso:code":"SM-02",
         "iso:id":"SM-02",
         "qs_pg:id":223302,
         "unlc:id":"SM-02",
         "wd:id":"Q206980",
         "wk:page":"Chiesanuova"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"24570279ddda779e11151d94fa46443e",
+    "wof:geomhash":"3faa1f527452c64271cf6dd6cca4289e",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -366,7 +368,7 @@
     "wof:lang_x_spoken":[
         "ita"
     ],
-    "wof:lastmodified":1690865845,
+    "wof:lastmodified":1695884331,
     "wof:name":"Chiesanuova",
     "wof:parent_id":85633763,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.